### PR TITLE
Add Code Guards for Airlocks Without Wires

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -449,9 +449,13 @@
 	return ((!secondsMainPowerLost || !secondsBackupPowerLost) && !(machine_stat & NOPOWER))
 
 /obj/machinery/door/airlock/requiresID()
+	if(!wires)
+		return FALSE
 	return !(wires.is_cut(WIRE_IDSCAN) || aiDisabledIdScanner)
 
 /obj/machinery/door/airlock/proc/isAllPowerCut()
+	if(!wires)
+		return TRUE
 	if((wires.is_cut(WIRE_POWER1) || wires.is_cut(WIRE_POWER2)) && (wires.is_cut(WIRE_BACKUP1) || wires.is_cut(WIRE_BACKUP2)))
 		return TRUE
 
@@ -461,6 +465,8 @@
 	update_appearance()
 
 /obj/machinery/door/airlock/proc/handlePowerRestore()
+	if(!wires)
+		return
 	var/cont = TRUE
 	while (cont)
 		sleep(10)
@@ -1292,7 +1298,7 @@
 
 
 /obj/machinery/door/airlock/close(forced=0)
-	if(operating || welded || locked || seal)
+	if(operating || welded || locked || seal || !wires)
 		return
 	if(density)
 		return TRUE
@@ -1452,7 +1458,8 @@
 
 	if(!panel_open)
 		panel_open = TRUE
-	wires.cut_all()
+	if(wires)
+		wires.cut_all()
 
 /obj/machinery/door/airlock/proc/set_electrified(seconds, mob/user)
 	secondsElectrified = seconds
@@ -1583,16 +1590,28 @@
 	data["opened"] = !density // opened
 
 	var/list/wire = list()
-	wire["main_1"] = !wires.is_cut(WIRE_POWER1)
-	wire["main_2"] = !wires.is_cut(WIRE_POWER2)
-	wire["backup_1"] = !wires.is_cut(WIRE_BACKUP1)
-	wire["backup_2"] = !wires.is_cut(WIRE_BACKUP2)
-	wire["shock"] = !wires.is_cut(WIRE_SHOCK)
-	wire["id_scanner"] = !wires.is_cut(WIRE_IDSCAN)
-	wire["bolts"] = !wires.is_cut(WIRE_BOLTS)
-	wire["lights"] = !wires.is_cut(WIRE_LIGHT)
-	wire["safe"] = !wires.is_cut(WIRE_SAFETY)
-	wire["timing"] = !wires.is_cut(WIRE_TIMING)
+	if(wires)
+		wire["main_1"] = !wires.is_cut(WIRE_POWER1)
+		wire["main_2"] = !wires.is_cut(WIRE_POWER2)
+		wire["backup_1"] = !wires.is_cut(WIRE_BACKUP1)
+		wire["backup_2"] = !wires.is_cut(WIRE_BACKUP2)
+		wire["shock"] = !wires.is_cut(WIRE_SHOCK)
+		wire["id_scanner"] = !wires.is_cut(WIRE_IDSCAN)
+		wire["bolts"] = !wires.is_cut(WIRE_BOLTS)
+		wire["lights"] = !wires.is_cut(WIRE_LIGHT)
+		wire["safe"] = !wires.is_cut(WIRE_SAFETY)
+		wire["timing"] = !wires.is_cut(WIRE_TIMING)
+	else
+		wire["main_1"] = TRUE
+		wire["main_2"] = TRUE
+		wire["backup_1"] = TRUE
+		wire["backup_2"] = TRUE
+		wire["shock"] = TRUE
+		wire["id_scanner"] = TRUE
+		wire["bolts"] = TRUE
+		wire["lights"] = TRUE
+		wire["safe"] = TRUE
+		wire["timing"] = TRUE
 
 	data["wires"] = wire
 	return data
@@ -1658,6 +1677,8 @@
 /obj/machinery/door/airlock/proc/shock_restore(mob/user)
 	if(!user_allowed(user))
 		return
+	if(!wires)
+		return
 	if(wires.is_cut(WIRE_SHOCK))
 		to_chat(user, span_warning("Can't un-electrify the airlock - The electrification wire is cut."))
 	else if(isElectrified())
@@ -1665,6 +1686,8 @@
 
 /obj/machinery/door/airlock/proc/shock_temp(mob/user)
 	if(!user_allowed(user))
+		return
+	if(!wires)
 		return
 	if(wires.is_cut(WIRE_SHOCK))
 		to_chat(user, span_warning("The electrification wire has been cut."))
@@ -1674,6 +1697,8 @@
 /obj/machinery/door/airlock/proc/shock_perm(mob/user)
 	if(!user_allowed(user))
 		return
+	if(!wires)
+		return
 	if(wires.is_cut(WIRE_SHOCK))
 		to_chat(user, span_warning("The electrification wire has been cut."))
 	else
@@ -1681,6 +1706,8 @@
 
 /obj/machinery/door/airlock/proc/toggle_bolt(mob/user)
 	if(!user_allowed(user))
+		return
+	if(!wires)
 		return
 	if(wires.is_cut(WIRE_BOLTS))
 		to_chat(user, span_warning("The door bolt drop wire is cut - you can't toggle the door bolts."))


### PR DESCRIPTION
One of the integration tests failed:
https://github.com/Starfly-13/sf13/actions/runs/24620249359/job/71989545373

Looks like a wooden airlock without wires spawned near a goliath pup who bumped into the airlock.
It wanted to check if the airlock needed an ID, and if so if the goliath pup had an ID to pass through the airlock.
However, because the airlock did not have wires, it couldn't call `is_cut()` on a `null`.

```
  Testing Ruin: Serene Hunts
  MAPGEN: MAPGEN REF [0x21013b50] (/datum/map_generator/planet_generator/jungle) STARTING TURF GEN
  MAPGEN: MAPGEN REF [0x21013b50] (/datum/map_generator/planet_generator/jungle) HAS FINISHED TURF GEN IN 5.3s
  [2026-04-19 03:45:27] Runtime in code/game/machinery/doors/airlock.dm,452: Cannot execute null.is cut().
    proc name: requiresID (/obj/machinery/door/airlock/requiresID)
    src: the wooden airlock (/obj/machinery/door/airlock/wood)
    src.loc: the floor (17,19,4) (/turf/open/floor/wood/ebony)
    call stack:
    the wooden airlock (/obj/machinery/door/airlock/wood): requiresID()
    the wooden airlock (/obj/machinery/door/airlock/wood): bumpopen(the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup))
    the wooden airlock (/obj/machinery/door/airlock/wood): bumpopen(the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup))
    the wooden airlock (/obj/machinery/door/airlock/wood): Bumped(the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup))
    the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup): Bump(the wooden airlock (/obj/machinery/door/airlock/wood))
    the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup): Bump(the wooden airlock (/obj/machinery/door/airlock/wood))
    the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup): Bump(the wooden airlock (/obj/machinery/door/airlock/wood))
    the floor (17,19,4) (/turf/open/floor/wood/ebony): Enter(the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup), null, 0)
    the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup): Move(the floor (17,19,4) (/turf/open/floor/wood/ebony), 1, 0, 1)
    the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup): Move(the floor (17,19,4) (/turf/open/floor/wood/ebony), 1, 0, null)
    the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup): Move(the floor (17,19,4) (/turf/open/floor/wood/ebony), 1, null, null)
    the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup): Move(the floor (17,19,4) (/turf/open/floor/wood/ebony), 1, null, null)
    the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup): handle automated movement()
    the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup): handle automated movement()
    NPC Pool (/datum/controller/subsystem/npcpool): fire(0)
    NPC Pool (/datum/controller/subsystem/npcpool): ignite(0)
    Master (/datum/controller/master): RunQueue()
    Master (/datum/controller/master): Loop(2)
    Master (/datum/controller/master): StartProcessing(0)
  MAPGEN: MAPGEN REF [0x21013b50] (/datum/map_generator/planet_generator/jungle) STARTING POST GEN
  MAPGEN: MAPGEN REF [0x21013b50] (/datum/map_generator/planet_generator/jungle) HAS FINISHED POST GEN IN 1.2s
  Cleaning up Foe (jungle planetoid)
  Error: [2026-04-19 03:45:27] Runtime in code/game/machinery/doors/airlock.dm,452: Cannot execute null.is cut().
    proc name: requiresID (/obj/machinery/door/airlock/requiresID)
    src: the wooden airlock (/obj/machinery/door/airlock/wood)
    src.loc: the floor (17,19,4) (/turf/open/floor/wood/ebony)
    call stack:
    the wooden airlock (/obj/machinery/door/airlock/wood): requiresID()
    the wooden airlock (/obj/machinery/door/airlock/wood): bumpopen(the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup))
    the wooden airlock (/obj/machinery/door/airlock/wood): bumpopen(the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup))
    the wooden airlock (/obj/machinery/door/airlock/wood): Bumped(the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup))
    the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup): Bump(the wooden airlock (/obj/machinery/door/airlock/wood))
    the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup): Bump(the wooden airlock (/obj/machinery/door/airlock/wood))
    the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup): Bump(the wooden airlock (/obj/machinery/door/airlock/wood))
    the floor (17,19,4) (/turf/open/floor/wood/ebony): Enter(the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup), null, 0)
    the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup): Move(the floor (17,19,4) (/turf/open/floor/wood/ebony), 1, 0, 1)
    the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup): Move(the floor (17,19,4) (/turf/open/floor/wood/ebony), 1, 0, null)
    the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup): Move(the floor (17,19,4) (/turf/open/floor/wood/ebony), 1, null, null)
    the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup): Move(the floor (17,19,4) (/turf/open/floor/wood/ebony), 1, null, null)
    the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup): handle automated movement()
    the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup): handle automated movement()
    NPC Pool (/datum/controller/subsystem/npcpool): fire(0)
    NPC Pool (/datum/controller/subsystem/npcpool): ignite(0)
    Master (/datum/controller/master): RunQueue()
    Master (/datum/controller/master): Loop(2)
    Master (/datum/controller/master): StartProcessing(0)
  	FAILURE #1: [2026-04-19 03:45:27] Runtime in code/game/machinery/doors/airlock.dm,452: Cannot execute null.is cut().
    proc name: requiresID (/obj/machinery/door/airlock/requiresID)
    src: the wooden airlock (/obj/machinery/door/airlock/wood)
    src.loc: the floor (17,19,4) (/turf/open/floor/wood/ebony)
    call stack:
    the wooden airlock (/obj/machinery/door/airlock/wood): requiresID()
    the wooden airlock (/obj/machinery/door/airlock/wood): bumpopen(the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup))
    the wooden airlock (/obj/machinery/door/airlock/wood): bumpopen(the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup))
    the wooden airlock (/obj/machinery/door/airlock/wood): Bumped(the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup))
    the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup): Bump(the wooden airlock (/obj/machinery/door/airlock/wood))
    the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup): Bump(the wooden airlock (/obj/machinery/door/airlock/wood))
    the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup): Bump(the wooden airlock (/obj/machinery/door/airlock/wood))
    the floor (17,19,4) (/turf/open/floor/wood/ebony): Enter(the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup), null, 0)
    the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup): Move(the floor (17,19,4) (/turf/open/floor/wood/ebony), 1, 0, 1)
    the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup): Move(the floor (17,19,4) (/turf/open/floor/wood/ebony), 1, 0, null)
    the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup): Move(the floor (17,19,4) (/turf/open/floor/wood/ebony), 1, null, null)
    the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup): Move(the floor (17,19,4) (/turf/open/floor/wood/ebony), 1, null, null)
    the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup): handle automated movement()
    the goliath pup (/mob/living/simple_animal/hostile/asteroid/goliath/pup): handle automated movement()
    NPC Pool (/datum/controller/subsystem/npcpool): fire(0)
    NPC Pool (/datum/controller/subsystem/npcpool): ignite(0)
    Master (/datum/controller/master): RunQueue()
    Master (/datum/controller/master): Loop(2)
    Master (/datum/controller/master): StartProcessing(0) at code/game/machinery/doors/airlock.dm:452
Error: FAIL /datum/unit_test/ruin_placement 90.2s
```

This PR adds some code guards in the airlock class everywhere `wires` is used.
If there are no wires, we just do nothing instead of crashing.
